### PR TITLE
Add the 'next' feature to choose between xdr::curr and xdr::next

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,18 @@ hex = "0.4.3"
 lazy_static = "1.4.0"
 nacl = "0.5.3"
 num-bigint = "0.4.3"
-rand_core = {version = "0.6.4", default-features = true, features = ["getrandom"]}
+rand_core = { version = "0.6.4", default-features = true, features = [
+  "getrandom",
+] }
 getrandom = { version = "0.2.10", features = ["js"] }
 sha2 = "0.10.7"
 stellar-strkey = "0.0.9"
-stellar-xdr =  { version = "22.0.0", default-features = true, features = ["base64", "std", "next", "serde", "alloc"] }
+stellar-xdr = { version = "22.1.0", default-features = true, features = [
+  "base64",
+  "std",
+  "serde",
+  "alloc",
+] }
 hex-literal = "0.4.1"
 num-traits = "0.2.15"
 hyper = "0.14.27"
@@ -34,3 +41,7 @@ serde_json = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libsodium-sys = "0.2.7"
+
+[features]
+default = []
+next = ["stellar-xdr/next"]

--- a/src/claimant.rs
+++ b/src/claimant.rs
@@ -1,42 +1,42 @@
 use stellar_strkey::ed25519::PublicKey;
-// use stellar_xdr::{VecM, ClaimPredicate};
+// use stellar_xdr::{xdr::VecM, xdr::ClaimPredicate};
 use crate::keypair::Keypair;
 use crate::keypair::KeypairBehavior;
-use stellar_xdr::next::{ClaimPredicate, VecM};
+use crate::xdr;
 
 pub struct Claimant {
     destination: Option<String>,
-    predicate: ClaimPredicate,
+    predicate: xdr::ClaimPredicate,
 }
 
 // Define a trait for Claimant behavior
 pub trait ClaimantBehavior {
     fn new(
         destination: Option<&str>,
-        predicate: Option<ClaimPredicate>,
+        predicate: Option<xdr::ClaimPredicate>,
     ) -> Result<Self, &'static str>
     where
         Self: Sized;
-    fn predicate_unconditional() -> ClaimPredicate;
-    fn predicate_and(left: ClaimPredicate, right: ClaimPredicate) -> ClaimPredicate;
-    fn predicate_or(left: ClaimPredicate, right: ClaimPredicate) -> ClaimPredicate;
-    fn predicate_not(predicate: ClaimPredicate) -> ClaimPredicate;
-    fn predicate_before_absolute_time(abs_before: i64) -> ClaimPredicate;
-    fn predicate_before_relative_time(seconds_str: &str) -> ClaimPredicate;
-    fn from_xdr(claimant_xdr: stellar_xdr::next::Claimant) -> Result<Self, &'static str>
+    fn predicate_unconditional() -> xdr::ClaimPredicate;
+    fn predicate_and(left: xdr::ClaimPredicate, right: xdr::ClaimPredicate) -> xdr::ClaimPredicate;
+    fn predicate_or(left: xdr::ClaimPredicate, right: xdr::ClaimPredicate) -> xdr::ClaimPredicate;
+    fn predicate_not(predicate: xdr::ClaimPredicate) -> xdr::ClaimPredicate;
+    fn predicate_before_absolute_time(abs_before: i64) -> xdr::ClaimPredicate;
+    fn predicate_before_relative_time(seconds_str: &str) -> xdr::ClaimPredicate;
+    fn from_xdr(claimant_xdr: xdr::Claimant) -> Result<Self, &'static str>
     where
         Self: Sized;
-    fn to_xdr_object(&self) -> stellar_xdr::next::Claimant;
+    fn to_xdr_object(&self) -> xdr::Claimant;
     fn destination(&self) -> Option<String>;
     fn set_destination(&mut self, value: String);
-    fn predicate(&self) -> &ClaimPredicate;
-    fn set_predicate(&mut self, value: ClaimPredicate);
+    fn predicate(&self) -> &xdr::ClaimPredicate;
+    fn set_predicate(&mut self, value: xdr::ClaimPredicate);
 }
 
 impl ClaimantBehavior for Claimant {
     fn new(
         destination: Option<&str>,
-        predicate: Option<ClaimPredicate>,
+        predicate: Option<xdr::ClaimPredicate>,
     ) -> Result<Self, &'static str> {
         let key = PublicKey::from_string(destination.unwrap());
 
@@ -46,7 +46,7 @@ impl ClaimantBehavior for Claimant {
 
         let actual_predicate = match predicate {
             Some(pred) => pred,
-            None => ClaimPredicate::Unconditional,
+            None => xdr::ClaimPredicate::Unconditional,
         };
 
         Ok(Claimant {
@@ -55,43 +55,43 @@ impl ClaimantBehavior for Claimant {
         })
     }
 
-    fn predicate_unconditional() -> ClaimPredicate {
-        ClaimPredicate::Unconditional
+    fn predicate_unconditional() -> xdr::ClaimPredicate {
+        xdr::ClaimPredicate::Unconditional
     }
 
-    fn predicate_and(left: ClaimPredicate, right: ClaimPredicate) -> ClaimPredicate {
+    fn predicate_and(left: xdr::ClaimPredicate, right: xdr::ClaimPredicate) -> xdr::ClaimPredicate {
         let cc = vec![left, right];
 
-        ClaimPredicate::And(VecM::<ClaimPredicate, 2>::try_from(cc).unwrap())
+        xdr::ClaimPredicate::And(xdr::VecM::<xdr::ClaimPredicate, 2>::try_from(cc).unwrap())
     }
 
-    fn predicate_or(left: ClaimPredicate, right: ClaimPredicate) -> ClaimPredicate {
+    fn predicate_or(left: xdr::ClaimPredicate, right: xdr::ClaimPredicate) -> xdr::ClaimPredicate {
         let cc = vec![left, right];
 
-        ClaimPredicate::Or(VecM::<ClaimPredicate, 2>::try_from(cc).unwrap())
+        xdr::ClaimPredicate::Or(xdr::VecM::<xdr::ClaimPredicate, 2>::try_from(cc).unwrap())
     }
 
-    fn predicate_not(predicate: ClaimPredicate) -> ClaimPredicate {
-        ClaimPredicate::Not(Some(Box::new(predicate)))
+    fn predicate_not(predicate: xdr::ClaimPredicate) -> xdr::ClaimPredicate {
+        xdr::ClaimPredicate::Not(Some(Box::new(predicate)))
     }
 
-    fn predicate_before_absolute_time(abs_before: i64) -> ClaimPredicate {
-        ClaimPredicate::BeforeAbsoluteTime(abs_before)
+    fn predicate_before_absolute_time(abs_before: i64) -> xdr::ClaimPredicate {
+        xdr::ClaimPredicate::BeforeAbsoluteTime(abs_before)
     }
 
-    fn predicate_before_relative_time(seconds_str: &str) -> ClaimPredicate {
+    fn predicate_before_relative_time(seconds_str: &str) -> xdr::ClaimPredicate {
         let seconds = seconds_str
             .parse::<i64>()
             .expect("Failed to parse seconds string to i64");
-        ClaimPredicate::BeforeRelativeTime(seconds)
+        xdr::ClaimPredicate::BeforeRelativeTime(seconds)
     }
 
-    fn from_xdr(claimant_xdr: stellar_xdr::next::Claimant) -> Result<Claimant, &'static str> {
+    fn from_xdr(claimant_xdr: xdr::Claimant) -> Result<Claimant, &'static str> {
         match claimant_xdr {
-            stellar_xdr::next::Claimant::ClaimantTypeV0(value) => {
+            xdr::Claimant::ClaimantTypeV0(value) => {
                 let destination_key = value.destination.0;
                 let val = match destination_key {
-                    stellar_xdr::next::PublicKey::PublicKeyTypeEd25519(x) => x.to_string(),
+                    xdr::PublicKey::PublicKeyTypeEd25519(x) => x.to_string(),
                 };
 
                 Ok(Claimant {
@@ -103,15 +103,15 @@ impl ClaimantBehavior for Claimant {
         }
     }
 
-    fn to_xdr_object(&self) -> stellar_xdr::next::Claimant {
-        let claimant = stellar_xdr::next::ClaimantV0 {
+    fn to_xdr_object(&self) -> xdr::Claimant {
+        let claimant = xdr::ClaimantV0 {
             destination: Keypair::from_public_key(self.destination.clone().unwrap().as_str())
                 .unwrap()
                 .xdr_account_id(),
             predicate: self.predicate.clone(),
         };
 
-        stellar_xdr::next::Claimant::ClaimantTypeV0(claimant)
+        xdr::Claimant::ClaimantTypeV0(claimant)
     }
 
     fn destination(&self) -> Option<String> {
@@ -122,11 +122,11 @@ impl ClaimantBehavior for Claimant {
         self.destination = Some(_value);
     }
 
-    fn predicate(&self) -> &ClaimPredicate {
+    fn predicate(&self) -> &xdr::ClaimPredicate {
         &self.predicate
     }
 
-    fn set_predicate(&mut self, _value: ClaimPredicate) {
+    fn set_predicate(&mut self, _value: xdr::ClaimPredicate) {
         self.predicate = _value;
     }
 }

--- a/src/get_liquidity_pool.rs
+++ b/src/get_liquidity_pool.rs
@@ -1,7 +1,8 @@
 use crate::hashing::HashingBehavior;
 use std::error::Error;
 
-use stellar_xdr::next::{LiquidityPoolParameters, WriteXdr};
+use crate::xdr;
+use crate::xdr::WriteXdr;
 
 use crate::asset::Asset;
 use crate::hashing::Sha256Hasher;
@@ -14,7 +15,7 @@ const LIQUIDITY_POOL_FEE_V18: i32 = 30;
 pub trait LiquidityPoolBehavior {
     fn get_liquidity_pool_id(
         liquidity_pool_type: &str,
-        liquidity_pool_parameters: LiquidityPoolParameters,
+        liquidity_pool_parameters: xdr::LiquidityPoolParameters,
     ) -> Result<Vec<u8>, Box<dyn Error>>;
 }
 
@@ -26,7 +27,7 @@ impl LiquidityPoolBehavior for LiquidityPool {
     /// Returns the raw Pool ID buffer.
     fn get_liquidity_pool_id(
         liquidity_pool_type: &str,
-        liquidity_pool_parameters: LiquidityPoolParameters,
+        liquidity_pool_parameters: xdr::LiquidityPoolParameters,
     ) -> Result<Vec<u8>, Box<dyn Error>> {
         if liquidity_pool_type != "constant_product" {
             return Err(Box::new(std::io::Error::new(
@@ -34,7 +35,7 @@ impl LiquidityPoolBehavior for LiquidityPool {
                 "liquidityPoolType is invalid",
             )));
         }
-        let LiquidityPoolParameters::LiquidityPoolConstantProduct(liquidity_pool_parametes_x) =
+        let xdr::LiquidityPoolParameters::LiquidityPoolConstantProduct(liquidity_pool_parametes_x) =
             liquidity_pool_parameters.clone();
 
         if liquidity_pool_parametes_x.fee != LIQUIDITY_POOL_FEE_V18 {
@@ -56,14 +57,14 @@ impl LiquidityPoolBehavior for LiquidityPool {
         }
         let va_1 = liquidity_pool_parametes_x.clone().asset_a;
 
-        let lp_type_data = stellar_xdr::next::LiquidityPoolType::LiquidityPoolConstantProduct
-            .to_xdr(stellar_xdr::next::Limits::none());
-        let lp_params_data = stellar_xdr::next::LiquidityPoolConstantProductParameters {
+        let lp_type_data =
+            xdr::LiquidityPoolType::LiquidityPoolConstantProduct.to_xdr(xdr::Limits::none());
+        let lp_params_data = xdr::LiquidityPoolConstantProductParameters {
             asset_a: liquidity_pool_parametes_x.clone().asset_a,
             asset_b: liquidity_pool_parametes_x.clone().asset_b,
             fee: liquidity_pool_parametes_x.fee,
         }
-        .to_xdr(stellar_xdr::next::Limits::none());
+        .to_xdr(xdr::Limits::none());
 
         let mut payload = Vec::new();
         payload.extend(lp_type_data.unwrap());

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -4,6 +4,10 @@
 //! public-key signature systems.
 use crate::hashing::HashingBehavior;
 use crate::hashing::Sha256Hasher;
+use crate::signing::{generate, sign, verify};
+use crate::xdr;
+use crate::xdr::WriteXdr;
+use hex::FromHex;
 use nacl::sign::{generate_keypair, signature};
 use rand_core::{OsRng, RngCore};
 use sha2::Sha512;
@@ -13,13 +17,6 @@ use stellar_strkey::{
     ed25519::{PrivateKey, PublicKey},
     Strkey,
 };
-use stellar_xdr::next::MuxedAccountMed25519;
-use stellar_xdr::next::{
-    AccountId, DecoratedSignature, Signature, SignatureHint, Uint256, Uint64, WriteXdr,
-};
-
-use crate::signing::{generate, sign, verify};
-use hex::FromHex;
 
 #[derive(Debug, Clone)]
 pub struct Keypair {
@@ -94,13 +91,13 @@ pub trait KeypairBehavior {
         Self: Sized;
 
     // XDR representation of the account id
-    fn xdr_account_id(&self) -> AccountId;
+    fn xdr_account_id(&self) -> xdr::AccountId;
 
     // XDR representation of the public key
-    fn xdr_public_key(&self) -> stellar_xdr::next::PublicKey;
+    fn xdr_public_key(&self) -> xdr::PublicKey;
 
     // XDR representation of the muxed account id
-    fn xdr_muxed_account_id(&self, id: &str) -> stellar_xdr::next::MuxedAccount;
+    fn xdr_muxed_account_id(&self, id: &str) -> xdr::MuxedAccount;
 
     // Returns the raw public key array
     fn raw_pubkey(&self) -> [u8; 32];
@@ -109,10 +106,10 @@ pub trait KeypairBehavior {
     fn signature_hint(&self) -> Option<Vec<u8>>;
 
     // Returns the decorated signature (hint+sig) for arbitrary data
-    fn sign_decorated(&self, data: &[u8]) -> DecoratedSignature;
+    fn sign_decorated(&self, data: &[u8]) -> xdr::DecoratedSignature;
 
     // Returns the raw decorated signature (hint+sig) for a signed payload signer
-    fn sign_payload_decorated(&self, data: &[u8]) -> DecoratedSignature;
+    fn sign_payload_decorated(&self, data: &[u8]) -> xdr::DecoratedSignature;
 }
 
 impl KeypairBehavior for Keypair {
@@ -276,24 +273,24 @@ impl KeypairBehavior for Keypair {
         }
     }
     /// xdr representation of the account id
-    fn xdr_account_id(&self) -> AccountId {
-        AccountId(stellar_xdr::next::PublicKey::PublicKeyTypeEd25519(Uint256(
+    fn xdr_account_id(&self) -> xdr::AccountId {
+        xdr::AccountId(xdr::PublicKey::PublicKeyTypeEd25519(xdr::Uint256(
             PublicKey::from_payload(&self.public_key).unwrap().0,
         )))
     }
 
     /// xdr representation of the public key
-    fn xdr_public_key(&self) -> stellar_xdr::next::PublicKey {
-        stellar_xdr::next::PublicKey::PublicKeyTypeEd25519(Uint256(
+    fn xdr_public_key(&self) -> xdr::PublicKey {
+        xdr::PublicKey::PublicKeyTypeEd25519(xdr::Uint256(
             PublicKey::from_payload(&self.public_key).unwrap().0,
         ))
     }
 
     /// xdr representation of the public key
-    fn xdr_muxed_account_id(&self, id: &str) -> stellar_xdr::next::MuxedAccount {
-        stellar_xdr::next::MuxedAccount::MuxedEd25519(MuxedAccountMed25519 {
-            id: Uint64::from_str(id).unwrap(),
-            ed25519: Uint256(PublicKey::from_payload(&self.public_key).unwrap().0),
+    fn xdr_muxed_account_id(&self, id: &str) -> xdr::MuxedAccount {
+        xdr::MuxedAccount::MuxedEd25519(xdr::MuxedAccountMed25519 {
+            id: xdr::Uint64::from_str(id).unwrap(),
+            ed25519: xdr::Uint256(PublicKey::from_payload(&self.public_key).unwrap().0),
         })
     }
 
@@ -310,7 +307,7 @@ impl KeypairBehavior for Keypair {
     /// part of the decorated signature
     fn signature_hint(&self) -> Option<Vec<u8>> {
         let a = Self::xdr_account_id(self)
-            .to_xdr(stellar_xdr::next::Limits::none())
+            .to_xdr(xdr::Limits::none())
             .unwrap();
         if a.len() >= 4 {
             let start_index = a.len() - 4;
@@ -321,27 +318,27 @@ impl KeypairBehavior for Keypair {
     }
 
     /// Returns the decorated signature (hint+sig) for arbitrary data.
-    fn sign_decorated(&self, data: &[u8]) -> DecoratedSignature {
+    fn sign_decorated(&self, data: &[u8]) -> xdr::DecoratedSignature {
         let signature = Self::sign(self, data).unwrap();
         let hint = Self::signature_hint(self).unwrap();
         let mut hint_u8: [u8; 4] = [0; 4];
         hint_u8.copy_from_slice(&hint[..4]);
-        let val = SignatureHint::from(hint_u8);
-        let signature_xdr = Signature::try_from(signature).unwrap();
-        stellar_xdr::next::DecoratedSignature {
+        let val = xdr::SignatureHint::from(hint_u8);
+        let signature_xdr = xdr::Signature::try_from(signature).unwrap();
+        xdr::DecoratedSignature {
             hint: val,
             signature: signature_xdr,
         }
     }
 
     /// Returns the raw decorated signature (hint+sig) for a signed payload signer.
-    fn sign_payload_decorated(&self, data: &[u8]) -> DecoratedSignature {
+    fn sign_payload_decorated(&self, data: &[u8]) -> xdr::DecoratedSignature {
         let signature = Self::sign(self, data).unwrap();
         let hint = Self::signature_hint(self).unwrap();
         let mut key_hint_u8: [u8; 4] = [0; 4];
         key_hint_u8.copy_from_slice(&hint[..4]);
-        let val = SignatureHint::from(key_hint_u8);
-        let signature_xdr = Signature::try_from(signature).unwrap();
+        let val = xdr::SignatureHint::from(key_hint_u8);
+        let signature_xdr = xdr::Signature::try_from(signature).unwrap();
         let mut hint: [u8; 4] = [0; 4];
 
         if data.len() >= 4 {
@@ -358,9 +355,9 @@ impl KeypairBehavior for Keypair {
             hint[i] ^= key_hint_u8[i];
         }
 
-        let val = SignatureHint::from(hint);
+        let val = xdr::SignatureHint::from(hint);
 
-        stellar_xdr::next::DecoratedSignature {
+        xdr::DecoratedSignature {
             hint: val,
             signature: signature_xdr,
         }
@@ -482,7 +479,7 @@ mod tests {
         let the_secret = "SD7X7LEHBNMUIKQGKPARG5TDJNBHKC346OUARHGZL5ITC6IJPXHILY36";
         let kp = Keypair::from_secret(&the_secret).unwrap();
         let message = "test post please ignore".as_bytes();
-        let sign: DecoratedSignature = kp.sign_decorated(&message);
+        let sign: xdr::DecoratedSignature = kp.sign_decorated(&message);
         assert_eq!(sign.hint.0.to_vec(), vec![0x0B, 0xFA, 0xD1, 0x34]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,5 +26,17 @@ pub mod transaction;
 pub mod transaction_builder;
 pub mod utils;
 pub mod xdr {
-    pub use stellar_xdr::*;
+    #[cfg(not(feature = "next"))]
+    pub use stellar_xdr::curr::*;
+
+    #[cfg(feature = "next")]
+    pub use stellar_xdr::next::*;
+
+    /*
+     * Why no consistent naming here?
+     */
+    #[cfg(not(feature = "next"))]
+    pub use stellar_xdr::curr::ExtensionPoint;
+    #[cfg(feature = "next")]
+    pub use stellar_xdr::next::SorobanTransactionDataExt as ExtensionPoint;
 }

--- a/src/op_list/create_account.rs
+++ b/src/op_list/create_account.rs
@@ -1,4 +1,5 @@
 use crate::operation::is_valid_amount;
+use crate::xdr;
 use crate::{
     keypair::*, operation::to_xdr_amount,
     utils::decode_encode_muxed_account::decode_address_to_muxed_account,
@@ -7,14 +8,11 @@ use hex_literal::hex;
 use sha2::digest::crypto_common::Key;
 use stellar_strkey::ed25519::PublicKey;
 use stellar_strkey::*;
-use stellar_xdr::next::MuxedAccount;
-use stellar_xdr::next::*;
-
 /// Creates and funds a new account with the specified starting balance
 pub fn create_account(
     destination: String,
     starting_balance: String,
-) -> Result<Operation, Box<dyn std::error::Error>> {
+) -> Result<xdr::Operation, Box<dyn std::error::Error>> {
     let key = PublicKey::from_string(&destination);
 
     if key.is_err() {
@@ -28,12 +26,12 @@ pub fn create_account(
         .unwrap()
         .xdr_account_id();
     let starting_balance = to_xdr_amount(&starting_balance)?;
-    let body = stellar_xdr::next::OperationBody::CreateAccount(CreateAccountOp {
+    let body = xdr::OperationBody::CreateAccount(xdr::CreateAccountOp {
         destination: dest,
         starting_balance,
     });
 
-    Ok(stellar_xdr::next::Operation {
+    Ok(xdr::Operation {
         source_account: None,
         body,
     })

--- a/src/signer_key.rs
+++ b/src/signer_key.rs
@@ -1,11 +1,12 @@
 use core::panic;
 use std::{collections::HashMap, str::FromStr};
 
+use crate::xdr;
+use crate::xdr::{SignerKey as XDRSignerKey, SignerKeyEd25519SignedPayload};
 use stellar_strkey::{
     ed25519::{PublicKey, SignedPayload},
     HashX, PreAuthTx,
 };
-use stellar_xdr::curr::{SignerKey as XDRSignerKey, SignerKeyEd25519SignedPayload};
 
 pub struct SignerKey;
 
@@ -25,19 +26,13 @@ impl SignerKeyBehavior for SignerKey {
         match val.unwrap() {
             stellar_strkey::Strkey::SignedPayloadEd25519(x) => {
                 XDRSignerKey::Ed25519SignedPayload(SignerKeyEd25519SignedPayload {
-                    ed25519: stellar_xdr::curr::Uint256(x.ed25519),
+                    ed25519: xdr::Uint256(x.ed25519),
                     payload: x.payload.try_into().unwrap(),
                 })
             }
-            stellar_strkey::Strkey::PublicKeyEd25519(x) => {
-                XDRSignerKey::Ed25519(stellar_xdr::curr::Uint256(x.0))
-            }
-            stellar_strkey::Strkey::PreAuthTx(x) => {
-                XDRSignerKey::PreAuthTx(stellar_xdr::curr::Uint256(x.0))
-            }
-            stellar_strkey::Strkey::HashX(x) => {
-                XDRSignerKey::HashX(stellar_xdr::curr::Uint256(x.0))
-            }
+            stellar_strkey::Strkey::PublicKeyEd25519(x) => XDRSignerKey::Ed25519(xdr::Uint256(x.0)),
+            stellar_strkey::Strkey::PreAuthTx(x) => XDRSignerKey::PreAuthTx(xdr::Uint256(x.0)),
+            stellar_strkey::Strkey::HashX(x) => XDRSignerKey::HashX(xdr::Uint256(x.0)),
             _ => panic!("Invalid Type"),
         }
     }
@@ -82,31 +77,31 @@ fn assert_panic<F: FnOnce(), S: AsRef<str>>(f: F, expected_msg: S) {
 }
 
 mod tests {
-    use stellar_xdr::curr::{ReadXdr, WriteXdr};
+    use xdr::{ReadXdr, WriteXdr};
 
     use super::*;
     #[derive(Debug)]
     struct TestCase {
         strkey: &'static str,
-        r#type: stellar_xdr::curr::SignerKeyType,
+        r#type: xdr::SignerKeyType,
     }
 
     static TEST_CASES: [TestCase; 4] = [
         TestCase {
             strkey: "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
-            r#type: stellar_xdr::curr::SignerKeyType::Ed25519,
+            r#type: xdr::SignerKeyType::Ed25519,
         },
         TestCase {
             strkey: "TBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWHXL7",
-            r#type: stellar_xdr::curr::SignerKeyType::PreAuthTx,
+            r#type: xdr::SignerKeyType::PreAuthTx,
         },
         TestCase {
             strkey: "XBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWGTOG",
-            r#type: stellar_xdr::curr::SignerKeyType::HashX,
+            r#type: xdr::SignerKeyType::HashX,
         },
         TestCase {
             strkey: "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAQACAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUPB6IBZGM",
-            r#type: stellar_xdr::curr::SignerKeyType::Ed25519SignedPayload,
+            r#type: xdr::SignerKeyType::Ed25519SignedPayload,
         },
     ];
 
@@ -117,10 +112,8 @@ mod tests {
 
             assert_eq!(skey.discriminant(), test_case.r#type);
 
-            let raw_xdr = skey.to_xdr(stellar_xdr::curr::Limits::none()).unwrap();
-            let raw_sk =
-                stellar_xdr::curr::SignerKey::from_xdr(raw_xdr, stellar_xdr::curr::Limits::none())
-                    .unwrap();
+            let raw_xdr = skey.to_xdr(xdr::Limits::none()).unwrap();
+            let raw_sk = xdr::SignerKey::from_xdr(raw_xdr, xdr::Limits::none()).unwrap();
             assert_eq!(raw_sk, skey);
 
             let address = SignerKey::encode_signer_key(&skey);

--- a/src/soroban_data_builder.rs
+++ b/src/soroban_data_builder.rs
@@ -1,14 +1,11 @@
-use stellar_xdr::{
-    curr::VecM,
-    next::{LedgerFootprint, ReadXdr, WriteXdr},
-};
-
+use crate::xdr;
+use crate::xdr::{ReadXdr, WriteXdr};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 
 pub struct SorobanDataBuilder {
-    data: stellar_xdr::next::SorobanTransactionData,
+    data: xdr::SorobanTransactionData,
 }
 
 pub enum Either<L, R> {
@@ -19,38 +16,35 @@ pub enum Either<L, R> {
 pub trait SorobanDataBuilderBehavior {
     fn append_footprint(
         &mut self,
-        read_only: Vec<stellar_xdr::next::LedgerKey>,
-        read_write: Vec<stellar_xdr::next::LedgerKey>,
+        read_only: Vec<xdr::LedgerKey>,
+        read_write: Vec<xdr::LedgerKey>,
     ) -> &mut Self;
     fn set_resources(&mut self, instructions: u32, read_bytes: u32, write_bytes: u32) -> &mut Self;
-    fn new(soroban_data: Option<Either<String, stellar_xdr::next::SorobanTransactionData>>)
-        -> Self;
-    fn from_xdr(data: Either<String, Vec<u8>>) -> stellar_xdr::next::SorobanTransactionData;
+    fn new(soroban_data: Option<Either<String, xdr::SorobanTransactionData>>) -> Self;
+    fn from_xdr(data: Either<String, Vec<u8>>) -> xdr::SorobanTransactionData;
     fn set_footprint(
         &mut self,
-        read_only: Option<Vec<stellar_xdr::next::LedgerKey>>,
-        read_write: Option<Vec<stellar_xdr::next::LedgerKey>>,
+        read_only: Option<Vec<xdr::LedgerKey>>,
+        read_write: Option<Vec<xdr::LedgerKey>>,
     ) -> &mut Self;
     fn set_refundable_fee(&mut self, fee: i64) -> &mut Self;
-    fn set_read_only(&mut self, read_only: Vec<stellar_xdr::next::LedgerKey>) -> &mut Self;
-    fn set_read_write(&mut self, read_write: Vec<stellar_xdr::next::LedgerKey>) -> &mut Self;
-    fn get_read_only(&self) -> &Vec<stellar_xdr::next::LedgerKey>;
-    fn get_read_write(&self) -> Vec<stellar_xdr::next::LedgerKey>;
-    fn build(&self) -> stellar_xdr::next::SorobanTransactionData;
-    fn get_footprint(&self) -> &stellar_xdr::next::LedgerFootprint;
+    fn set_read_only(&mut self, read_only: Vec<xdr::LedgerKey>) -> &mut Self;
+    fn set_read_write(&mut self, read_write: Vec<xdr::LedgerKey>) -> &mut Self;
+    fn get_read_only(&self) -> &Vec<xdr::LedgerKey>;
+    fn get_read_write(&self) -> Vec<xdr::LedgerKey>;
+    fn build(&self) -> xdr::SorobanTransactionData;
+    fn get_footprint(&self) -> &xdr::LedgerFootprint;
 }
 impl SorobanDataBuilderBehavior for SorobanDataBuilder {
-    fn new(
-        soroban_data: Option<Either<String, stellar_xdr::next::SorobanTransactionData>>,
-    ) -> Self {
+    fn new(soroban_data: Option<Either<String, xdr::SorobanTransactionData>>) -> Self {
         let data = match soroban_data {
             Some(Either::Left(encoded_data)) => {
                 if encoded_data.is_empty() {
                     // Return default empty data for empty string
-                    stellar_xdr::next::SorobanTransactionData {
-                        ext: stellar_xdr::next::SorobanTransactionDataExt::V0,
-                        resources: stellar_xdr::next::SorobanResources {
-                            footprint: LedgerFootprint {
+                    xdr::SorobanTransactionData {
+                        ext: xdr::ExtensionPoint::V0,
+                        resources: xdr::SorobanResources {
+                            footprint: xdr::LedgerFootprint {
                                 read_only: Vec::new().try_into().unwrap(),
                                 read_write: Vec::new().try_into().unwrap(),
                             },
@@ -66,14 +60,12 @@ impl SorobanDataBuilderBehavior for SorobanDataBuilder {
                 }
             }
             Some(Either::Right(data_instance)) => SorobanDataBuilder::from_xdr(Either::Left(
-                data_instance
-                    .to_xdr_base64(stellar_xdr::next::Limits::none())
-                    .unwrap(),
+                data_instance.to_xdr_base64(xdr::Limits::none()).unwrap(),
             )),
-            None => stellar_xdr::next::SorobanTransactionData {
-                ext: stellar_xdr::next::SorobanTransactionDataExt::V0,
-                resources: stellar_xdr::next::SorobanResources {
-                    footprint: LedgerFootprint {
+            None => xdr::SorobanTransactionData {
+                ext: xdr::ExtensionPoint::V0,
+                resources: xdr::SorobanResources {
+                    footprint: xdr::LedgerFootprint {
                         read_only: Vec::new().try_into().unwrap(),
                         read_write: Vec::new().try_into().unwrap(),
                     },
@@ -89,25 +81,21 @@ impl SorobanDataBuilderBehavior for SorobanDataBuilder {
         Self { data }
     }
 
-    fn from_xdr(data: Either<String, Vec<u8>>) -> stellar_xdr::next::SorobanTransactionData {
+    fn from_xdr(data: Either<String, Vec<u8>>) -> xdr::SorobanTransactionData {
         match data {
-            Either::Left(encoded) => stellar_xdr::next::SorobanTransactionData::from_xdr_base64(
-                encoded,
-                stellar_xdr::next::Limits::none(),
-            )
-            .unwrap(),
-            Either::Right(raw) => stellar_xdr::next::SorobanTransactionData::from_xdr(
-                raw,
-                stellar_xdr::next::Limits::none(),
-            )
-            .unwrap(),
+            Either::Left(encoded) => {
+                xdr::SorobanTransactionData::from_xdr_base64(encoded, xdr::Limits::none()).unwrap()
+            }
+            Either::Right(raw) => {
+                xdr::SorobanTransactionData::from_xdr(raw, xdr::Limits::none()).unwrap()
+            }
         }
     }
 
     fn append_footprint(
         &mut self,
-        read_only: Vec<stellar_xdr::next::LedgerKey>,
-        read_write: Vec<stellar_xdr::next::LedgerKey>,
+        read_only: Vec<xdr::LedgerKey>,
+        read_write: Vec<xdr::LedgerKey>,
     ) -> &mut Self {
         // Get current footprints
         let mut current_read_only = self.get_read_only().clone();
@@ -123,8 +111,8 @@ impl SorobanDataBuilderBehavior for SorobanDataBuilder {
 
     fn set_footprint(
         &mut self,
-        read_only: Option<Vec<stellar_xdr::next::LedgerKey>>,
-        read_write: Option<Vec<stellar_xdr::next::LedgerKey>>,
+        read_only: Option<Vec<xdr::LedgerKey>>,
+        read_write: Option<Vec<xdr::LedgerKey>>,
     ) -> &mut Self {
         if let Some(ros) = read_only {
             self.set_read_only(ros);
@@ -140,35 +128,33 @@ impl SorobanDataBuilderBehavior for SorobanDataBuilder {
         self
     }
 
-    fn set_read_only(&mut self, read_only: Vec<stellar_xdr::next::LedgerKey>) -> &mut Self {
+    fn set_read_only(&mut self, read_only: Vec<xdr::LedgerKey>) -> &mut Self {
         self.data.resources.footprint.read_only = read_only.try_into().unwrap();
         self
     }
 
-    fn set_read_write(&mut self, read_write: Vec<stellar_xdr::next::LedgerKey>) -> &mut Self {
+    fn set_read_write(&mut self, read_write: Vec<xdr::LedgerKey>) -> &mut Self {
         self.data.resources.footprint.read_write = read_write.try_into().unwrap();
         self
     }
 
-    fn get_read_only(&self) -> &Vec<stellar_xdr::next::LedgerKey> {
+    fn get_read_only(&self) -> &Vec<xdr::LedgerKey> {
         &self.data.resources.footprint.read_only
     }
 
-    fn get_read_write(&self) -> Vec<stellar_xdr::next::LedgerKey> {
+    fn get_read_write(&self) -> Vec<xdr::LedgerKey> {
         self.data.resources.footprint.read_write.to_vec()
     }
 
-    fn build(&self) -> stellar_xdr::next::SorobanTransactionData {
-        stellar_xdr::next::SorobanTransactionData::from_xdr_base64(
-            self.data
-                .to_xdr_base64(stellar_xdr::next::Limits::none())
-                .unwrap(),
-            stellar_xdr::next::Limits::none(),
+    fn build(&self) -> xdr::SorobanTransactionData {
+        xdr::SorobanTransactionData::from_xdr_base64(
+            self.data.to_xdr_base64(xdr::Limits::none()).unwrap(),
+            xdr::Limits::none(),
         )
         .unwrap()
     }
 
-    fn get_footprint(&self) -> &stellar_xdr::next::LedgerFootprint {
+    fn get_footprint(&self) -> &xdr::LedgerFootprint {
         &self.data.resources.footprint
     }
 
@@ -181,21 +167,17 @@ impl SorobanDataBuilderBehavior for SorobanDataBuilder {
 }
 #[cfg(test)]
 mod tests {
-    use crate::contract::{ContractBehavior, Contracts};
-
     use super::*;
-    use stellar_xdr::next::{
-        ExtensionPoint, LedgerFootprint, LedgerKey, Limits, SorobanResources,
-        SorobanTransactionData,
-    };
+    use crate::contract::{ContractBehavior, Contracts};
+    use crate::xdr;
 
     #[test]
     fn test_constructs_from_xdr_base64_and_nothing() {
         // Create sentinel data that matches the JS test
-        let sentinel = SorobanTransactionData {
-            ext: stellar_xdr::next::SorobanTransactionDataExt::V0,
-            resources: SorobanResources {
-                footprint: LedgerFootprint {
+        let sentinel = xdr::SorobanTransactionData {
+            ext: xdr::ExtensionPoint::V0,
+            resources: xdr::SorobanResources {
+                footprint: xdr::LedgerFootprint {
                     read_only: Vec::new().try_into().unwrap(),
                     read_write: Vec::new().try_into().unwrap(),
                 },
@@ -214,7 +196,7 @@ mod tests {
         assert_eq!(from_raw, sentinel);
 
         // Test construction from base64 string (equivalent to fromStr)
-        let base64_str = sentinel.to_xdr_base64(Limits::none()).unwrap();
+        let base64_str = sentinel.to_xdr_base64(xdr::Limits::none()).unwrap();
         let from_str = SorobanDataBuilder::new(Some(Either::Left(base64_str))).build();
         assert_eq!(from_str, sentinel);
 
@@ -234,10 +216,10 @@ mod tests {
     #[test]
     fn test_sets_properties_as_expected() {
         // Create sentinel data
-        let sentinel = SorobanTransactionData {
-            ext: stellar_xdr::next::SorobanTransactionDataExt::V0,
-            resources: SorobanResources {
-                footprint: LedgerFootprint {
+        let sentinel = xdr::SorobanTransactionData {
+            ext: xdr::ExtensionPoint::V0,
+            resources: xdr::SorobanResources {
+                footprint: xdr::LedgerFootprint {
                     read_only: Vec::new().try_into().unwrap(),
                     read_write: Vec::new().try_into().unwrap(),
                 },

--- a/src/utils/decode_encode_muxed_account.rs
+++ b/src/utils/decode_encode_muxed_account.rs
@@ -1,9 +1,9 @@
 use crate::muxed_account;
+use crate::xdr;
 use arrayref::array_ref;
 use std::str::FromStr;
 use stellar_strkey::ed25519::{MuxedAccount, PublicKey};
 use stellar_strkey::Strkey::MuxedAccountEd25519;
-use stellar_xdr::next::{Uint256, Uint64};
 
 pub fn decode_address_to_muxed_account(address: &str) -> MuxedAccount {
     if MuxedAccount::from_str(address).is_ok() {
@@ -14,18 +14,16 @@ pub fn decode_address_to_muxed_account(address: &str) -> MuxedAccount {
 }
 
 // TODO: 'G..' address was not working for payment Op, need to make different function, with better name
-pub fn decode_address_to_muxed_account_fix_for_g_address(
-    address: &str,
-) -> stellar_xdr::next::MuxedAccount {
+pub fn decode_address_to_muxed_account_fix_for_g_address(address: &str) -> xdr::MuxedAccount {
     if MuxedAccount::from_str(address).is_ok() {
         let val = decode_address_fully_to_muxed_account(address);
         return val;
     }
 
-    stellar_xdr::next::MuxedAccount::from_str(address).unwrap()
+    xdr::MuxedAccount::from_str(address).unwrap()
 }
 
-pub fn encode_muxed_account(address: &str, id: &str) -> stellar_xdr::next::MuxedAccount {
+pub fn encode_muxed_account(address: &str, id: &str) -> xdr::MuxedAccount {
     let key = PublicKey::from_string(address);
 
     if key.is_err() {
@@ -37,43 +35,41 @@ pub fn encode_muxed_account(address: &str, id: &str) -> stellar_xdr::next::Muxed
 
     let vv = key.clone().unwrap().0;
 
-    stellar_xdr::next::MuxedAccount::MuxedEd25519(stellar_xdr::next::MuxedAccountMed25519 {
+    xdr::MuxedAccount::MuxedEd25519(xdr::MuxedAccountMed25519 {
         id: id.parse::<u64>().unwrap(),
-        ed25519: Uint256(*array_ref!(vv, 0, 32)),
+        ed25519: xdr::Uint256(*array_ref!(vv, 0, 32)),
     })
 }
 
-pub fn encode_muxed_account_to_address(muxed_account: &stellar_xdr::next::MuxedAccount) -> String {
-    if muxed_account.discriminant() == stellar_xdr::next::CryptoKeyType::MuxedEd25519 {
+pub fn encode_muxed_account_to_address(muxed_account: &xdr::MuxedAccount) -> String {
+    if muxed_account.discriminant() == xdr::CryptoKeyType::MuxedEd25519 {
         return _encode_muxed_account_fully_to_address(muxed_account);
     }
 
     let inner_value = match muxed_account {
-        stellar_xdr::next::MuxedAccount::Ed25519(inner) => inner,
+        xdr::MuxedAccount::Ed25519(inner) => inner,
         _ => panic!("Expected Ed25519 variant"),
     };
 
     PublicKey::from_payload(&inner_value.0).unwrap().to_string()
 }
-pub fn decode_address_fully_to_muxed_account(address: &str) -> stellar_xdr::next::MuxedAccount {
+pub fn decode_address_fully_to_muxed_account(address: &str) -> xdr::MuxedAccount {
     let binding = MuxedAccount::from_str(address).unwrap();
-    let id = Uint64::from_str(&binding.id.to_string()).unwrap();
+    let id = xdr::Uint64::from_str(&binding.id.to_string()).unwrap();
     let key = binding.ed25519;
-    stellar_xdr::next::MuxedAccount::MuxedEd25519(stellar_xdr::next::MuxedAccountMed25519 {
+    xdr::MuxedAccount::MuxedEd25519(xdr::MuxedAccountMed25519 {
         id,
-        ed25519: Uint256(*array_ref!(key, 0, 32)),
+        ed25519: xdr::Uint256(*array_ref!(key, 0, 32)),
     })
 }
 
-pub fn _encode_muxed_account_fully_to_address(
-    muxed_account: &stellar_xdr::next::MuxedAccount,
-) -> String {
-    if muxed_account.discriminant() == stellar_xdr::next::CryptoKeyType::Ed25519 {
+pub fn _encode_muxed_account_fully_to_address(muxed_account: &xdr::MuxedAccount) -> String {
+    if muxed_account.discriminant() == xdr::CryptoKeyType::Ed25519 {
         return encode_muxed_account_to_address(muxed_account);
     }
 
     let inner_value = match muxed_account {
-        stellar_xdr::next::MuxedAccount::MuxedEd25519(inner) => inner,
+        xdr::MuxedAccount::MuxedEd25519(inner) => inner,
         _ => panic!("Expected Ed25519 variant"),
     };
 

--- a/src/xdr.rs
+++ b/src/xdr.rs
@@ -1,2 +1,0 @@
-//! Reexporting the stellar_xdr library
-pub use stellar_xdr as xdr;


### PR DESCRIPTION
Use a feature to enable/disable the "next" feature of stellar-xdr. In the current state it is possible to mismatch both curr and next modules.
This is a breaking change.

There might be an issue to check with SorobanDataTransactionExt.